### PR TITLE
POC-846 Add signed message in loan creation

### DIFF
--- a/contracts/LiquidationsPeripheral.vy
+++ b/contracts/LiquidationsPeripheral.vy
@@ -230,6 +230,7 @@ def _computeLiquidationInterestAmount(principal: uint256, interestAmount: uint25
 @view
 @internal
 def _getNFTXVaultAddrFromCollateralAddr(_collateralAddress: address) -> address:
+    assert self.nftxVaultFactoryAddress != empty(address), "nftx vault address not defined"
     vault_addrs: DynArray[address, 20] = INFTXVaultFactory(self.nftxVaultFactoryAddress).vaultsForAsset(_collateralAddress)
     
     if len(vault_addrs) == 0:

--- a/contracts/Loans.vy
+++ b/contracts/Loans.vy
@@ -47,6 +47,20 @@ struct Loan:
     canceled: bool
 
 
+struct EIP712Domain:
+    name: String[100]
+    version: String[10]
+    chain_id: uint256
+    verifying_contract: address
+
+struct ReserveMessageContent:
+    amount: uint256
+    interest: uint256
+    maturity: uint256
+    collaterals: DynArray[Collateral, 100]
+    deadline: uint256
+
+
 # Events
 
 event OwnershipTransferred:
@@ -157,18 +171,6 @@ event LoanCreated:
     loanId: uint256
     erc20TokenContract: address
 
-event LoanValidated:
-    walletIndexed: indexed(address)
-    wallet: address
-    loanId: uint256
-    erc20TokenContract: address
-
-event LoanInvalidated:
-    walletIndexed: indexed(address)
-    wallet: address
-    loanId: uint256
-    erc20TokenContract: address
-
 event LoanPayment:
     walletIndexed: indexed(address)
     wallet: address
@@ -223,6 +225,18 @@ walletsWhitelisted: public(HashMap[address, bool])
 
 collectionsAmount: HashMap[address, uint256] # aux variable
 
+ZHARTA_DOMAIN_NAME: constant(String[6])    = "Zharta"
+ZHARTA_DOMAIN_VERSION: constant(String[1]) = "1"
+
+COLLATERAL_TYPE_DEF: constant(String[66])  = "Collateral(address contractAddress,uint256 tokenId,uint256 amount)"
+RESERVE_TYPE_DEF: constant(String[179])    = "ReserveMessageContent(uint256 amount,uint256 interest,uint256 maturity,Collateral[] collaterals,uint256 deadline)" \
+                                             "Collateral(address contractAddress,uint256 tokenId,uint256 amount)"
+DOMAIN_TYPE_HASH: constant(bytes32)        = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
+COLLATERAL_TYPE_HASH: constant(bytes32)    = keccak256(COLLATERAL_TYPE_DEF)
+RESERVE_TYPE_HASH: constant(bytes32)       = keccak256(RESERVE_TYPE_DEF)
+
+reserve_message_typehash: bytes32
+reserve_sig_domain_separator: bytes32
 
 @external
 def __init__(
@@ -250,6 +264,13 @@ def __init__(
     self.collateralVaultPeripheralContract = _collateralVaultPeripheralContract
     self.isAcceptingLoans = True
 
+    self.reserve_sig_domain_separator = keccak256(_abi_encode(
+                DOMAIN_TYPE_HASH,
+                keccak256(ZHARTA_DOMAIN_NAME),
+                keccak256(ZHARTA_DOMAIN_VERSION),
+                convert(1, uint256),
+                self,
+                ))
 
 @internal
 def _areCollateralsWhitelisted(_collaterals: DynArray[Collateral, 100]) -> bool:
@@ -660,11 +681,16 @@ def reserve(
     _amount: uint256,
     _interest: uint256,
     _maturity: uint256,
-    _collaterals: DynArray[Collateral, 100]
+    _collaterals: DynArray[Collateral, 100],
+    _deadline: uint256,
+    _v: uint256,
+    _r: uint256,
+    _s: uint256
 ) -> uint256:
     assert not self.isDeprecated, "contract is deprecated"
     assert self.isAcceptingLoans, "contract is not accepting loans"
     assert block.timestamp <= _maturity, "maturity is in the past"
+    assert block.timestamp <= _deadline, "deadline has passed"
     assert _maturity - block.timestamp <= self.maxAllowedLoanDuration, "maturity exceeds the max allowed"
     assert self._areCollateralsWhitelisted(_collaterals), "not all NFTs are accepted"
     assert self._areCollateralsOwned(msg.sender, _collaterals), "msg.sender does not own all NFTs"
@@ -673,6 +699,7 @@ def reserve(
     assert ILendingPoolPeripheral(self.lendingPoolPeripheralContract).maxFundsInvestable() >= _amount, "insufficient liquidity"
     assert ILoansCore(self.loansCoreContract).ongoingLoans(msg.sender) < self.maxAllowedLoans, "max loans already reached"
     assert _amount <= self.maxLoanAmount, "loan amount > than the max value"
+
     assert ILiquidityControls(self.liquidityControlsContract).withinLoansPoolShareLimit(
         msg.sender,
         _amount,
@@ -683,6 +710,24 @@ def reserve(
 
     if self.walletWhitelistEnabled and not self.walletsWhitelisted[msg.sender]:
         raise "msg.sender is not whitelisted"
+
+    # signature validation
+    collaterals_data_hash: DynArray[bytes32, 100] = []
+    for c in _collaterals:
+        collaterals_data_hash.append(keccak256(_abi_encode(COLLATERAL_TYPE_HASH, c.contractAddress, c.tokenId, c.amount)))
+
+    data_hash: bytes32 = keccak256(_abi_encode(
+                RESERVE_TYPE_HASH,
+                _amount,
+                _interest,
+                _maturity,
+                keccak256(slice(_abi_encode(collaterals_data_hash), 32*2, 32*len(_collaterals))),
+                _deadline,
+                ))
+
+    sig_hash: bytes32 = keccak256(concat(convert("\x19\x01", Bytes[2]), _abi_encode(self.reserve_sig_domain_separator, data_hash)))
+    signer: address = ecrecover(sig_hash, _v, _r, _s)
+    assert signer == self.owner, "invalid message signature"
 
     newLoanId: uint256 = ILoansCore(self.loansCoreContract).addLoan(
         msg.sender,
@@ -710,65 +755,19 @@ def reserve(
         ILendingPoolPeripheral(self.lendingPoolPeripheralContract).erc20TokenContract()
     )
 
+    ILoansCore(self.loansCoreContract).updateLoanStarted(msg.sender, newLoanId)
+    ILoansCore(self.loansCoreContract).updateHighestSingleCollateralLoan(msg.sender, newLoanId)
+    ILoansCore(self.loansCoreContract).updateHighestCollateralBundleLoan(msg.sender, newLoanId)
+
+    ILendingPoolPeripheral(self.lendingPoolPeripheralContract).sendFunds(
+        msg.sender,
+        ILoansCore(self.loansCoreContract).getLoanAmount(msg.sender, newLoanId)
+    )
+
     return newLoanId
 
 
-@external
-def validate(_borrower: address, _loanId: uint256):
-    assert msg.sender == self.owner, "msg.sender is not the owner"
-    assert not self.isDeprecated, "contract is deprecated"
-    assert self.isAcceptingLoans, "contract is not accepting loans"
-    assert ILoansCore(self.loansCoreContract).isLoanCreated(_borrower, _loanId), "loan not found"
-    assert not ILoansCore(self.loansCoreContract).isLoanStarted(_borrower, _loanId), "loan already validated"
-    assert not ILoansCore(self.loansCoreContract).getLoanInvalidated(_borrower, _loanId), "loan already invalidated"
-    assert block.timestamp <= ILoansCore(self.loansCoreContract).getLoanMaturity(_borrower, _loanId), "maturity is in the past"
-    assert self._areCollateralsWhitelisted(ILoansCore(self.loansCoreContract).getLoanCollaterals(_borrower, _loanId)), "not all NFTs are accepted"
-    assert ILendingPoolPeripheral(self.lendingPoolPeripheralContract).maxFundsInvestable() >= ILoansCore(self.loansCoreContract).getLoanAmount(_borrower, _loanId), "insufficient liquidity"
 
-    ILoansCore(self.loansCoreContract).updateLoanStarted(_borrower, _loanId)
-    ILoansCore(self.loansCoreContract).updateHighestSingleCollateralLoan(_borrower, _loanId)
-    ILoansCore(self.loansCoreContract).updateHighestCollateralBundleLoan(_borrower, _loanId)
-
-    ILendingPoolPeripheral(self.lendingPoolPeripheralContract).sendFunds(
-        _borrower,
-        ILoansCore(self.loansCoreContract).getLoanAmount(_borrower, _loanId)
-    )
-
-    log LoanValidated(
-        _borrower,
-        _borrower,
-        _loanId,
-        ILendingPoolPeripheral(self.lendingPoolPeripheralContract).erc20TokenContract()
-    )
-
-
-@external
-def invalidate(_borrower: address, _loanId: uint256):
-    assert msg.sender == self.owner, "msg.sender is not the owner"
-    assert ILoansCore(self.loansCoreContract).isLoanCreated(_borrower, _loanId), "loan not found"
-    assert not ILoansCore(self.loansCoreContract).isLoanStarted(_borrower, _loanId), "loan already validated"
-    assert not ILoansCore(self.loansCoreContract).getLoanInvalidated(_borrower, _loanId), "loan already invalidated"
-    
-    ILoansCore(self.loansCoreContract).updateInvalidLoan(_borrower, _loanId)
-
-    collaterals: DynArray[Collateral, 100] = ILoansCore(self.loansCoreContract).getLoanCollaterals(_borrower, _loanId)
-    for collateral in collaterals:
-        ILoansCore(self.loansCoreContract).removeCollateralFromLoan(_borrower, collateral, _loanId)
-        ILoansCore(self.loansCoreContract).updateCollaterals(collateral, True)
-
-        ICollateralVaultPeripheral(self.collateralVaultPeripheralContract).transferCollateralFromLoan(
-            _borrower,
-            collateral.contractAddress,
-            collateral.tokenId,
-            ILendingPoolPeripheral(self.lendingPoolPeripheralContract).erc20TokenContract()
-        )
-
-    log LoanInvalidated(
-        _borrower,
-        _borrower,
-        _loanId,
-        ILendingPoolPeripheral(self.lendingPoolPeripheralContract).erc20TokenContract()
-    )
 
 
 @external
@@ -871,29 +870,3 @@ def settleDefault(_borrower: address, _loanId: uint256):
     )
 
 
-@external
-def cancelPendingLoan(_loanId: uint256):
-    assert ILoansCore(self.loansCoreContract).isLoanCreated(msg.sender, _loanId), "loan not found"
-    assert not ILoansCore(self.loansCoreContract).isLoanStarted(msg.sender, _loanId), "loan already validated"
-    assert not ILoansCore(self.loansCoreContract).getLoanInvalidated(msg.sender, _loanId), "loan already invalidated"
-
-    ILoansCore(self.loansCoreContract).updateCanceledLoan(msg.sender, _loanId)
-
-    collaterals: DynArray[Collateral, 100] = ILoansCore(self.loansCoreContract).getLoanCollaterals(msg.sender, _loanId)
-    for collateral in collaterals:
-        ILoansCore(self.loansCoreContract).removeCollateralFromLoan(msg.sender, collateral, _loanId)
-        ILoansCore(self.loansCoreContract).updateCollaterals(collateral, True)
-
-        ICollateralVaultPeripheral(self.collateralVaultPeripheralContract).transferCollateralFromLoan(
-            msg.sender,
-            collateral.contractAddress,
-            collateral.tokenId,
-            ILendingPoolPeripheral(self.lendingPoolPeripheralContract).erc20TokenContract()
-        )
-
-    log PendingLoanCanceled(
-        msg.sender,
-        msg.sender,
-        _loanId,
-        ILendingPoolPeripheral(self.lendingPoolPeripheralContract).erc20TokenContract()
-    )

--- a/contracts/Loans.vy
+++ b/contracts/Loans.vy
@@ -192,12 +192,6 @@ event LoanDefaulted:
     amount: uint256
     erc20TokenContract: address
 
-event PendingLoanCanceled:
-    walletIndexed: indexed(address)
-    wallet: address
-    loanId: uint256
-    erc20TokenContract: address
-
 
 # Global variables
 

--- a/interfaces/ILoans.vy
+++ b/interfaces/ILoans.vy
@@ -129,11 +129,6 @@ event LoanDefaulted:
     loanId: uint256
     amount: uint256
     erc20TokenContract: address
-event PendingLoanCanceled:
-    walletIndexed: address
-    wallet: address
-    loanId: uint256
-    erc20TokenContract: address
 
 # Functions
 

--- a/interfaces/ILoans.vy
+++ b/interfaces/ILoans.vy
@@ -111,16 +111,6 @@ event LoanCreated:
     wallet: address
     loanId: uint256
     erc20TokenContract: address
-event LoanValidated:
-    walletIndexed: address
-    wallet: address
-    loanId: uint256
-    erc20TokenContract: address
-event LoanInvalidated:
-    walletIndexed: address
-    wallet: address
-    loanId: uint256
-    erc20TokenContract: address
 event LoanPayment:
     walletIndexed: address
     wallet: address
@@ -226,15 +216,7 @@ def getLoanPayableAmount(_borrower: address, _loanId: uint256, _timestamp: uint2
     pass
 
 @external
-def reserve(_amount: uint256, _interest: uint256, _maturity: uint256, _collaterals: DynArray[Collateral, 100]) -> uint256:
-    pass
-
-@external
-def validate(_borrower: address, _loanId: uint256):
-    pass
-
-@external
-def invalidate(_borrower: address, _loanId: uint256):
+def reserve(_amount: uint256, _interest: uint256, _maturity: uint256, _collaterals: DynArray[Collateral, 100], _deadline: uint256, _v: uint256, _r: uint256, _s: uint256) -> uint256:
     pass
 
 @external
@@ -243,10 +225,6 @@ def pay(_loanId: uint256):
 
 @external
 def settleDefault(_borrower: address, _loanId: uint256):
-    pass
-
-@external
-def cancelPendingLoan(_loanId: uint256):
     pass
 
 @view

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ LOCK_PERIOD_DURATION = 7 * 24 * 60 * 60
 
 
 contract_owner = conftest_base.contract_owner
+not_contract_owner = conftest_base.not_contract_owner
 investor = conftest_base.investor
 borrower = conftest_base.borrower
 protocol_wallet = conftest_base.protocol_wallet

--- a/tests/conftest_base.py
+++ b/tests/conftest_base.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture(scope="module", autouse=True)
 def contract_owner(accounts):
-    yield accounts[0]
+    return accounts.add('0xbb4b8e7e4375d27f27518ac7f8c6db473fdc3a10a42389cf984c87bc7a1fce1b')
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -20,6 +20,9 @@ def borrower(accounts):
 def protocol_wallet(accounts):
     yield accounts[3]
 
+@pytest.fixture(scope="module", autouse=True)
+def not_contract_owner(accounts):
+    return accounts.add()
 
 @pytest.fixture(scope="module", autouse=True)
 def erc20_contract(ERC20, contract_owner):


### PR DESCRIPTION
## Purpose of this PR 🎯

<!-- Check at least one of the following options with an "x". -->
-   [ ] Feature;
-   [ ] Bugfix;
-   [ ] Tests;
-   [x ] Refactoring;
-   [ ] Build or CI/CD; 
-   [ ] Documentation;
-   [ ] Code Styling;
-   [ ] Other. Please describe:

## Changes 📝

Add signed message support for loan creation (`reserve`)
Remove the `validate`, `invalidate` and `cancelPendingLoan` functions from Loans
Remove the `LoanValidated` and `LoanInvalidated` events
<!-- If applicable add screenshots or videos that illustrate any new or updated UIs. -->

## Test Coverage 🧻

Adapted tests to new function signature
<!-- Add test coverage related to the introduced changes. -->

## Does this PR introduce a breaking change? ⚠️

-   [ ] No
-   [ x] Yes

<!-- If yes, please describe the impact. -->

New version of Loans contract
## Related issues 📎

<!-- If this PR refers to a JIRA ticket, uncomment and insert the issue number. -->
<!-- JIRA issue [POC-XXX](https://zharta.atlassian.net/browse/POC-XXX)-->

<!-- If this PR closes an issue, uncomment and insert the issue number. -->
<!-- Closes #ISSUE_NUMBER.-->

<!-- If not applicable, uncomment the line below. -->
<!-- _Not Applicable_ -->

<!-- If this PR depends on another PR, uncomment and add it below. -->
<!-- ### :warning: This PR depends on #XXX. -->
<!-- Give a quick overview of what is depending on. -->

## Reviewers 🦺

@DioPires 

<!-- If applicable add other reviewers. -->
