### PR TITLE
fix: change lpcore receiveFunds to consider invested amount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ install: venv
 install-dev: venv install
 	${PIP} install -r requirements-dev.txt
 
+test: export FORK=false
 test: venv install-dev
 	patch contracts/LiquidationsPeripheral.vy tests/nftx_workaround.patch
 	${VENV}/bin/brownie test ; patch -R contracts/LiquidationsPeripheral.vy tests/nftx_workaround.patch

--- a/contracts/LendingPoolCore.vy
+++ b/contracts/LendingPoolCore.vy
@@ -82,14 +82,7 @@ def _computeShares(_amount: uint256) -> uint256:
 def _computeWithdrawableAmount(_lender: address) -> uint256:
     if self.totalSharesBasisPoints == 0:
         return 0
-
-    withdrawable: uint256 = (self.fundsAvailable + self.fundsInvested) * self.funds[_lender].sharesBasisPoints / self.totalSharesBasisPoints
-
-    # due to rounding errors
-    if self.funds[_lender].currentAmountDeposited > withdrawable:
-        return self.funds[_lender].currentAmountDeposited
-
-    return withdrawable
+    return (self.fundsAvailable + self.fundsInvested) * self.funds[_lender].sharesBasisPoints / self.totalSharesBasisPoints
 
 
 ##### EXTERNAL METHODS - VIEW #####
@@ -305,15 +298,15 @@ def sendFunds(_to: address, _amount: uint256) -> bool:
 
 
 @external
-def receiveFunds(_borrower: address, _amount: uint256, _rewardsAmount: uint256) -> bool:
-    # _amount and _rewardsAmount should be passed in wei
+def receiveFunds(_borrower: address, _amount: uint256, _rewardsAmount: uint256, _investedAmount: uint256) -> bool:
+    # _amount,_rewardsAmount and _investedAmount should be passed in wei
 
     assert msg.sender == self.lendingPoolPeripheral, "msg.sender is not LP peripheral"
     assert _borrower != empty(address), "_borrower is the zero address"
     assert _amount + _rewardsAmount > 0, "Amount has to be higher than 0"
 
     self.fundsAvailable += _amount + _rewardsAmount
-    self.fundsInvested -= _amount
+    self.fundsInvested -= _investedAmount
     self.totalRewards += _rewardsAmount
 
     return IERC20(self.erc20TokenContract).transferFrom(_borrower, self, _amount + _rewardsAmount)

--- a/contracts/LendingPoolPeripheral.vy
+++ b/contracts/LendingPoolPeripheral.vy
@@ -686,7 +686,7 @@ def sendFunds(_to: address, _amount: uint256):
 
 
 @external
-def receiveFunds(_borrower: address, _amount: uint256, _rewardsAmount: uint256, _investedAmount: uint256):
+def receiveFunds(_borrower: address, _amount: uint256, _rewardsAmount: uint256):
     # _amount and _rewardsAmount should be passed in wei
 
     assert msg.sender == self.loansContract, "msg.sender is not the loans addr"
@@ -694,7 +694,7 @@ def receiveFunds(_borrower: address, _amount: uint256, _rewardsAmount: uint256, 
     assert self._fundsAreAllowed(_borrower, self.lendingPoolCoreContract, _amount + _rewardsAmount), "insufficient liquidity"
     assert _amount + _rewardsAmount > 0, "amount should be higher than 0"
     
-    self._receiveFunds(_borrower, _amount, _rewardsAmount, _investedAmount)
+    self._receiveFunds(_borrower, _amount, _rewardsAmount, _amount)
 
 
 @external

--- a/contracts/LiquidationsPeripheral.vy
+++ b/contracts/LiquidationsPeripheral.vy
@@ -688,6 +688,7 @@ def payLoanLiquidationsGracePeriod(_loanId: uint256, _erc20TokenContract: addres
             liquidation.principal,
             liquidation.gracePeriodPrice - liquidation.principal,
             True,
+            liquidation.principal,
             "liquidation_grace_period"
         )
 
@@ -712,7 +713,7 @@ def payLoanLiquidationsGracePeriod(_loanId: uint256, _erc20TokenContract: addres
 
 
 @external
-def buyNFTGracePeriod(_collateralAddress: address, _tokenId: uint256):   
+def buyNFTGracePeriod(_collateralAddress: address, _tokenId: uint256):
     liquidation: Liquidation = ILiquidationsCore(self.liquidationsCoreAddress).getLiquidation(_collateralAddress, _tokenId)
     assert block.timestamp <= liquidation.gracePeriodMaturity, "liquidation out of grace period"
     assert msg.sender == liquidation.borrower, "msg.sender is not borrower"
@@ -736,6 +737,7 @@ def buyNFTGracePeriod(_collateralAddress: address, _tokenId: uint256):
         liquidation.principal,
         liquidation.gracePeriodPrice - liquidation.principal,
         True,
+        liquidation.principal,
         "liquidation_grace_period"
     )
 
@@ -803,6 +805,7 @@ def buyNFTLenderPeriod(_collateralAddress: address, _tokenId: uint256):
         liquidation.principal,
         lenderPeriodInterestAmount,
         True,
+        liquidation.principal,
         "liquidation_lenders_period"
     )
 
@@ -907,6 +910,7 @@ def liquidateNFTX(_collateralAddress: address, _tokenId: uint256):
         principal,
         interestAmount,
         distributeToProtocol,
+        liquidation.principal,
         "liquidation_nftx"
     )
 
@@ -960,7 +964,7 @@ def adminWithdrawal(_walletAddress: address, _collateralAddress: address, _token
     )
 
 @external
-def adminLiquidation(_principal: uint256, _interestAmount: uint256, _liquidationId: bytes32, _erc20TokenContract: address, _collateralAddress: address, _tokenId: uint256):
+def adminLiquidation(_principal: uint256, _interestAmount: uint256, _loanPrincipal: uint256, _liquidationId: bytes32, _erc20TokenContract: address, _collateralAddress: address, _tokenId: uint256):
     assert msg.sender == self.owner, "msg.sender is not the owner"
     assert not ICollateralVaultPeripheral(self.collateralVaultPeripheralAddress).isCollateralInVault(_collateralAddress, _tokenId), "collateral still owned by vault"
 
@@ -972,6 +976,7 @@ def adminLiquidation(_principal: uint256, _interestAmount: uint256, _liquidation
         _principal,
         _interestAmount,
         True,
+        _loanPrincipal,
         "admin_liquidation"
     )
 

--- a/contracts/Loans.vy
+++ b/contracts/Loans.vy
@@ -17,7 +17,7 @@ interface ILendingPoolPeripheral:
     def maxFundsInvestable() -> uint256: view 
     def erc20TokenContract() -> address: view
     def sendFunds(_to: address, _amount: uint256): nonpayable
-    def receiveFunds(_borrower: address, _amount: uint256, _rewardsAmount: uint256): nonpayable
+    def receiveFunds(_borrower: address, _amount: uint256, _rewardsAmount: uint256, _investedAmount: uint256): nonpayable
     def lendingPoolCoreContract() -> address: view
 
 interface ILiquidationsPeripheral:
@@ -820,7 +820,7 @@ def pay(_loanId: uint256):
     ILoansCore(self.loansCoreContract).updatePaidLoan(msg.sender, _loanId)
     ILoansCore(self.loansCoreContract).updateHighestRepayment(msg.sender, _loanId)
 
-    ILendingPoolPeripheral(self.lendingPoolPeripheralContract).receiveFunds(msg.sender, loan.amount, paidInterestAmount)
+    ILendingPoolPeripheral(self.lendingPoolPeripheralContract).receiveFunds(msg.sender, loan.amount, paidInterestAmount, loan.amount)
 
     for collateral in loan.collaterals:
         ILoansCore(self.loansCoreContract).removeCollateralFromLoan(msg.sender, collateral, _loanId)

--- a/contracts/Loans.vy
+++ b/contracts/Loans.vy
@@ -17,7 +17,7 @@ interface ILendingPoolPeripheral:
     def maxFundsInvestable() -> uint256: view 
     def erc20TokenContract() -> address: view
     def sendFunds(_to: address, _amount: uint256): nonpayable
-    def receiveFunds(_borrower: address, _amount: uint256, _rewardsAmount: uint256, _investedAmount: uint256): nonpayable
+    def receiveFunds(_borrower: address, _amount: uint256, _rewardsAmount: uint256): nonpayable
     def lendingPoolCoreContract() -> address: view
 
 interface ILiquidationsPeripheral:
@@ -820,7 +820,7 @@ def pay(_loanId: uint256):
     ILoansCore(self.loansCoreContract).updatePaidLoan(msg.sender, _loanId)
     ILoansCore(self.loansCoreContract).updateHighestRepayment(msg.sender, _loanId)
 
-    ILendingPoolPeripheral(self.lendingPoolPeripheralContract).receiveFunds(msg.sender, loan.amount, paidInterestAmount, loan.amount)
+    ILendingPoolPeripheral(self.lendingPoolPeripheralContract).receiveFunds(msg.sender, loan.amount, paidInterestAmount)
 
     for collateral in loan.collaterals:
         ILoansCore(self.loansCoreContract).removeCollateralFromLoan(msg.sender, collateral, _loanId)

--- a/contracts/migration/LPCMigration01.vy
+++ b/contracts/migration/LPCMigration01.vy
@@ -1,0 +1,54 @@
+# @version ^0.3.6
+
+# Interfaces
+
+from interfaces import ILendingPoolCore
+
+# Structs
+
+struct InvestorFunds:
+    currentAmountDeposited: uint256
+    totalAmountDeposited: uint256
+    totalAmountWithdrawn: uint256
+    sharesBasisPoints: uint256
+    lockPeriodEnd: uint256
+    activeForRewards: bool
+
+# Events
+
+
+# Global variables
+
+owner: public(address)
+oldContract: public(address)
+newContract: public(address)
+
+##### INTERNAL METHODS #####
+
+
+##### EXTERNAL METHODS - VIEW #####
+
+
+##### EXTERNAL METHODS - WRITE #####
+
+@external
+def __init__(_from: address, _to: address):
+    assert _from != empty(address), "address it the zero address"
+    assert _to != empty(address), "address it the zero address"
+    self.owner = msg.sender
+    self.oldContract = _from
+    self.newContract = _to
+
+
+@external
+def migrate():
+    assert msg.sender == self.owner, "msg.sender is not the owner"
+
+    ILendingPoolCore(self.oldContract).claimOwnership()
+    ILendingPoolCore(self.newContract).claimOwnership()
+
+    ILendingPoolCore(self.newContract).migrate(self.oldContract)
+
+    ILendingPoolCore(self.newContract).proposeOwner(self.owner)
+
+    selfdestruct(self.owner)

--- a/interfaces/ILendingPoolCore.vy
+++ b/interfaces/ILendingPoolCore.vy
@@ -76,6 +76,10 @@ def activeForRewards(_lender: address) -> bool:
     pass
 
 @external
+def migrate(_from: address):
+    pass
+
+@external
 def proposeOwner(_address: address):
     pass
 

--- a/interfaces/ILendingPoolCore.vy
+++ b/interfaces/ILendingPoolCore.vy
@@ -100,7 +100,7 @@ def sendFunds(_to: address, _amount: uint256) -> bool:
     pass
 
 @external
-def receiveFunds(_borrower: address, _amount: uint256, _rewardsAmount: uint256) -> bool:
+def receiveFunds(_borrower: address, _amount: uint256, _rewardsAmount: uint256, _investedAmount: uint256) -> bool:
     pass
 
 @external

--- a/interfaces/ILendingPoolPeripheral.vy
+++ b/interfaces/ILendingPoolPeripheral.vy
@@ -96,6 +96,7 @@ event FundsReceipt:
     amount: uint256
     rewardsPool: uint256
     rewardsProtocol: uint256
+    investedAmount: uint256
     erc20TokenContract: address
     fundsOrigin: String[30]
 
@@ -186,11 +187,11 @@ def sendFunds(_to: address, _amount: uint256):
     pass
 
 @external
-def receiveFunds(_borrower: address, _amount: uint256, _rewardsAmount: uint256):
+def receiveFunds(_borrower: address, _amount: uint256, _rewardsAmount: uint256, _investedAmount: uint256):
     pass
 
 @external
-def receiveFundsFromLiquidation(_borrower: address, _amount: uint256, _rewardsAmount: uint256, _distributeToProtocol: bool, _origin: String[30]):
+def receiveFundsFromLiquidation(_borrower: address, _amount: uint256, _rewardsAmount: uint256, _distributeToProtocol: bool, _investedAmount: uint256, _origin: String[30]):
     pass
 
 @view

--- a/interfaces/ILendingPoolPeripheral.vy
+++ b/interfaces/ILendingPoolPeripheral.vy
@@ -187,7 +187,7 @@ def sendFunds(_to: address, _amount: uint256):
     pass
 
 @external
-def receiveFunds(_borrower: address, _amount: uint256, _rewardsAmount: uint256, _investedAmount: uint256):
+def receiveFunds(_borrower: address, _amount: uint256, _rewardsAmount: uint256):
     pass
 
 @external

--- a/tests/test_lendingpool_peripheral.py
+++ b/tests/test_lendingpool_peripheral.py
@@ -846,7 +846,6 @@ def test_receive_funds_wrong_sender(lending_pool_peripheral_contract, loans_peri
             borrower,
             Web3.toWei(0.2, "ether"),
             Web3.toWei(0.05, "ether"),
-            Web3.toWei(0.2, "ether"),
             {"from": borrower}
         )
 
@@ -859,7 +858,6 @@ def test_receive_funds_insufficient_amount(lending_pool_peripheral_contract, loa
             borrower,
             Web3.toWei(0.2, "ether"),
             Web3.toWei(0.05, "ether"),
-            Web3.toWei(0.2, "ether"),
             {"from": loans_peripheral_contract}
         )
 
@@ -870,7 +868,6 @@ def test_receive_funds_zero_value(lending_pool_peripheral_contract, loans_periph
     with brownie.reverts("amount should be higher than 0"):
         lending_pool_peripheral_contract.receiveFunds(
             borrower,
-            Web3.toWei(0, "ether"),
             Web3.toWei(0, "ether"),
             Web3.toWei(0, "ether"),
             {"from": loans_peripheral_contract}
@@ -909,7 +906,6 @@ def test_receive_funds(
         borrower,
         Web3.toWei(0.2, "ether"),
         Web3.toWei(0.02, "ether"),
-        Web3.toWei(0.2, "ether"),
         {"from": loans_peripheral_contract}
     )
 
@@ -973,7 +969,6 @@ def test_receive_funds_multiple_lenders(
         borrower,
         Web3.toWei(0.2, "ether"),
         Web3.toWei(0.02, "ether"),
-        Web3.toWei(0.2, "ether"),
         {"from": loans_peripheral_contract}
     )
 

--- a/tests/test_lendingpool_peripheral.py
+++ b/tests/test_lendingpool_peripheral.py
@@ -846,6 +846,7 @@ def test_receive_funds_wrong_sender(lending_pool_peripheral_contract, loans_peri
             borrower,
             Web3.toWei(0.2, "ether"),
             Web3.toWei(0.05, "ether"),
+            Web3.toWei(0.2, "ether"),
             {"from": borrower}
         )
 
@@ -858,6 +859,7 @@ def test_receive_funds_insufficient_amount(lending_pool_peripheral_contract, loa
             borrower,
             Web3.toWei(0.2, "ether"),
             Web3.toWei(0.05, "ether"),
+            Web3.toWei(0.2, "ether"),
             {"from": loans_peripheral_contract}
         )
 
@@ -868,6 +870,7 @@ def test_receive_funds_zero_value(lending_pool_peripheral_contract, loans_periph
     with brownie.reverts("amount should be higher than 0"):
         lending_pool_peripheral_contract.receiveFunds(
             borrower,
+            Web3.toWei(0, "ether"),
             Web3.toWei(0, "ether"),
             Web3.toWei(0, "ether"),
             {"from": loans_peripheral_contract}
@@ -906,6 +909,7 @@ def test_receive_funds(
         borrower,
         Web3.toWei(0.2, "ether"),
         Web3.toWei(0.02, "ether"),
+        Web3.toWei(0.2, "ether"),
         {"from": loans_peripheral_contract}
     )
 
@@ -928,6 +932,7 @@ def test_receive_funds(
     assert tx_receive.events["FundsReceipt"]["amount"] == Web3.toWei(0.2, "ether")
     assert tx_receive.events["FundsReceipt"]["rewardsPool"] == Web3.toWei(expectedPoolFees, "ether")
     assert tx_receive.events["FundsReceipt"]["rewardsProtocol"] == Web3.toWei(expectedProtocolFees, "ether")
+    assert tx_receive.events["FundsReceipt"]["investedAmount"] == Web3.toWei(0.2, "ether")
     assert tx_receive.events["FundsReceipt"]["erc20TokenContract"] == erc20_contract
     assert tx_receive.events["FundsReceipt"]["fundsOrigin"] == "loan"
 
@@ -968,6 +973,7 @@ def test_receive_funds_multiple_lenders(
         borrower,
         Web3.toWei(0.2, "ether"),
         Web3.toWei(0.02, "ether"),
+        Web3.toWei(0.2, "ether"),
         {"from": loans_peripheral_contract}
     )
 
@@ -995,5 +1001,6 @@ def test_receive_funds_multiple_lenders(
     assert tx_receive.events["FundsReceipt"]["amount"] == Web3.toWei(0.2, "ether")
     assert tx_receive.events["FundsReceipt"]["rewardsPool"] == Web3.toWei(expectedPoolFees, "ether")
     assert tx_receive.events["FundsReceipt"]["rewardsProtocol"] == Web3.toWei(expectedProtocolFees, "ether")
+    assert tx_receive.events["FundsReceipt"]["investedAmount"] == Web3.toWei(0.2, "ether")
     assert tx_receive.events["FundsReceipt"]["erc20TokenContract"] == erc20_contract
     assert tx_receive.events["FundsReceipt"]["fundsOrigin"] == "loan"

--- a/tests/test_liquidations_peripheral.py
+++ b/tests/test_liquidations_peripheral.py
@@ -1219,6 +1219,7 @@ def test_admin_liquidation(
     collateral_address = liquidation['collateralAddress']
     token_id = liquidation['tokenId']
     loan_id = loan['id']
+    investedAmount = liquidation["principal"]
 
     chain.mine(blocks=1, timedelta=GRACE_PERIOD_DURATION+LENDER_PERIOD_DURATION+1)
     liquidations_peripheral_contract.adminWithdrawal(contract_owner, collateral_address, token_id, {"from": contract_owner})
@@ -1227,6 +1228,7 @@ def test_admin_liquidation(
     tx = liquidations_peripheral_contract.adminLiquidation(
         LOAN_AMOUNT*7//10,
         LOAN_AMOUNT*1//10,
+        investedAmount,
         liquidation_id,
         liquidation['erc20TokenContract'],
         collateral_address,
@@ -1254,6 +1256,7 @@ def test_admin_liquidation(
 
     event_funds_receipt = tx.events["FundsReceipt"]
     assert event_funds_receipt["fundsOrigin"] == "admin_liquidation"
+    assert event_funds_receipt["investedAmount"] == investedAmount
 
 
 def test_admin_liquidation_fail_on_message_not_from_owner(
@@ -1295,6 +1298,7 @@ def test_admin_liquidation_fail_on_message_not_from_owner(
         tx = liquidations_peripheral_contract.adminLiquidation(
             LOAN_AMOUNT*7//10,
             LOAN_AMOUNT*1//10,
+            liquidation["principal"],
             liquidation['lid'],
             liquidation['erc20TokenContract'],
             collateral_address,
@@ -1347,6 +1351,7 @@ def test_admin_liquidation_fail_on_collateral_in_vault(
         tx = liquidations_peripheral_contract.adminLiquidation(
             LOAN_AMOUNT*7//10,
             LOAN_AMOUNT*1//10,
+            liquidation["principal"],
             liquidation['lid'],
             liquidation['erc20TokenContract'],
             collateral_address,
@@ -1400,6 +1405,7 @@ def test_admin_liquidation_fail_on_collateral_in_liquidation(
         tx = liquidations_peripheral_contract.adminLiquidation(
             LOAN_AMOUNT*7//10,
             LOAN_AMOUNT*1//10,
+            liquidation["principal"],
             liquidation['lid'],
             liquidation['erc20TokenContract'],
             collateral_address,


### PR DESCRIPTION
## Purpose of this PR 🎯

<!-- Check at least one of the following options with an "x". -->
-   [ ] Feature;
-   [x] Bugfix;
-   [ ] Tests;
-   [ ] Refactoring;
-   [ ] Build or CI/CD; 
-   [ ] Documentation;
-   [ ] Code Styling;
-   [ ] Other. Please describe:

## Changes 📝

This PR adds an `investedAmount` parameter to `LendingPoolCore.receiveFunds` so that losses can be reflected in the pool balance.

<!-- Describe the changes introduced by this PR. -->
<!-- If applicable add screenshots or videos that illustrate any new or updated UIs. -->

## Test Coverage 🧻

<!-- Add test coverage related to the introduced changes. -->

## Does this PR introduce a breaking change? ⚠️

-   [ ] No
-   [x] Yes

Public functions:
* `LendingPoolCore.receiveFunds`
* `LendingPoolPeripheral.receiveFunds`
* `LiquidationsPeripheral.adminLiquidation`

Events:
* `FundsReceipt`

<!-- If yes, please describe the impact. -->

## Related issues 📎

<!-- If this PR refers to a JIRA ticket, uncomment and insert the issue number. -->
JIRA issue [POC-1076](https://zharta.atlassian.net/browse/POC-1076)

<!-- If this PR closes an issue, uncomment and insert the issue number. -->
<!-- Closes #ISSUE_NUMBER.-->

<!-- If not applicable, uncomment the line below. -->
<!-- _Not Applicable_ -->

<!-- If this PR depends on another PR, uncomment and add it below. -->
<!-- ### :warning: This PR depends on #XXX. -->
<!-- Give a quick overview of what is depending on. -->

## Reviewers 🦺

@DioPires 

<!-- If applicable add other reviewers. -->
