### PR TITLE
add lockedAmount function in lending pool peripheral

### DIFF
--- a/contracts/LendingPoolPeripheral.vy
+++ b/contracts/LendingPoolPeripheral.vy
@@ -482,6 +482,17 @@ def theoreticalMaxFundsInvestableAfterDeposit(_amount: uint256) -> uint256:
 def lenderFunds(_lender: address) -> InvestorFunds:
     return ILendingPoolCore(self.lendingPoolCoreContract).funds(_lender)
 
+@view
+@external
+def lockedAmount(_lender: address) -> uint256:
+    if not ILiquidityControls(self.liquidityControlsContract).lockPeriodEnabled():
+        return 0
+
+    lockPeriod: InvestorLock = ILendingPoolLock(self.lendingPoolLockContract).investorLocks(_lender)
+    if lockPeriod.lockPeriodEnd < block.timestamp:
+        return 0
+    return lockPeriod.lockPeriodAmount
+
 
 ##### EXTERNAL METHODS - NON-VIEW #####
 

--- a/interfaces/ILendingPoolPeripheral.vy
+++ b/interfaces/ILendingPoolPeripheral.vy
@@ -232,6 +232,11 @@ def theoreticalMaxFundsInvestableAfterDeposit(_amount: uint256) -> uint256:
 def lenderFunds(_lender: address) -> InvestorFunds:
     pass
 
+@view
+@external
+def lockedAmount(_lender: address) -> uint256:
+    pass
+
 @external
 def proposeOwner(_address: address):
     pass


### PR DESCRIPTION
## Purpose of this PR 🎯

<!-- Check at least one of the following options with an "x". -->
-   [x] Feature;
-   [ ] Bugfix;
-   [ ] Tests;
-   [ ] Refactoring;
-   [ ] Build or CI/CD; 
-   [ ] Documentation;
-   [ ] Code Styling;
-   [ ] Other. Please describe:

## Changes 📝

This PR adds a single function in `LendingPoolPeripheral` to retrieve the lender's locked amount. Currently getting that information requires calling `LendingPoolLock` to get the amount and deadline and cross-checking with `LiquidityControls` to validate if the lender's locking is enabled.

<!-- Describe the changes introduced by this PR. -->
<!-- If applicable add screenshots or videos that illustrate any new or updated UIs. -->

## Test Coverage 🧻

<!-- Add test coverage related to the introduced changes. -->

## Does this PR introduce a breaking change? ⚠️

-   [ ] No
-   [ ] Yes

<!-- If yes, please describe the impact. -->

## Related issues 📎

<!-- If this PR refers to a JIRA ticket, uncomment and insert the issue number. -->
<!-- JIRA issue [POC-XXX](https://zharta.atlassian.net/browse/POC-XXX)-->

<!-- If this PR closes an issue, uncomment and insert the issue number. -->
<!-- Closes #ISSUE_NUMBER.-->

<!-- If not applicable, uncomment the line below. -->
<!-- _Not Applicable_ -->

<!-- If this PR depends on another PR, uncomment and add it below. -->
<!-- ### :warning: This PR depends on #XXX. -->
<!-- Give a quick overview of what is depending on. -->

## Reviewers 🦺

<!-- @DioPires -->

<!-- If applicable add other reviewers. -->
