### PR TITLE
Change floor_multiple_cap to null in art blocks

### DIFF
--- a/configs/dev/collections.json
+++ b/configs/dev/collections.json
@@ -143,7 +143,7 @@
       "type": "range"
     },
     "debt_limit": 200,
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "looksrare_url": "https://looksrare.org/collections/0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a",
     "mapped_address": "0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a",
     "name": "[Internal] Chromie Squiggle",
@@ -284,7 +284,7 @@
       "type": "range"
     },
     "debt_limit": 125,
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "looksrare_url": "https://looksrare.org/collections/0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "mapped_address": "0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "name": "[Internal] Fidenza",
@@ -323,7 +323,7 @@
       "type": "range"
     },
     "debt_limit": 50,
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "looksrare_url": "https://looksrare.org/collections/0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "mapped_address": "0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "name": "[Internal] Gazers",
@@ -634,7 +634,7 @@
       "type": "range"
     },
     "debt_limit": 50,
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "looksrare_url": "https://looksrare.org/collections/0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "mapped_address": "0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "name": "[Internal] Ringers",

--- a/configs/int/collections.json
+++ b/configs/int/collections.json
@@ -143,7 +143,7 @@
       "type": "range"
     },
     "debt_limit": 200,
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "looksrare_url": "https://looksrare.org/collections/0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a",
     "mapped_address": "0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a",
     "name": "[Goerli] Chromie Squiggle",
@@ -284,7 +284,7 @@
       "type": "range"
     },
     "debt_limit": 125,
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "looksrare_url": "https://looksrare.org/collections/0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "mapped_address": "0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "name": "[Goerli] Fidenza",
@@ -323,7 +323,7 @@
       "type": "range"
     },
     "debt_limit": 50,
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "looksrare_url": "https://looksrare.org/collections/0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "mapped_address": "0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "name": "[Goerli] Gazers",
@@ -634,7 +634,7 @@
       "type": "range"
     },
     "debt_limit": 50,
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "looksrare_url": "https://looksrare.org/collections/0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "mapped_address": "0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "name": "[Goerli] Ringers",

--- a/configs/local/collections.json
+++ b/configs/local/collections.json
@@ -152,7 +152,7 @@
       "interest_rate": 0.02055,
       "max_ltv": 0.6
     },
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "tier_pricing": {
       "30d": {
         "apr": 0.25,
@@ -293,7 +293,7 @@
       "interest_rate": 0.02055,
       "max_ltv": 0.6
     },
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "tier_pricing": {
       "30d": {
         "apr": 0.25,
@@ -332,7 +332,7 @@
       "interest_rate": 0.02877,
       "max_ltv": 0.55
     },
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "tier_pricing": {
       "30d": {
         "apr": 0.35,
@@ -643,7 +643,7 @@
       "interest_rate": 0.02877,
       "max_ltv": 0.55
     },
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "tier_pricing": {
       "30d": {
         "apr": 0.35,

--- a/configs/prod/collections.json
+++ b/configs/prod/collections.json
@@ -143,7 +143,7 @@
       "type": "range"
     },
     "debt_limit": 200,
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "looksrare_url": "https://looksrare.org/collections/0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a",
     "mapped_address": "0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a",
     "name": "Chromie Squiggle",
@@ -284,7 +284,7 @@
       "type": "range"
     },
     "debt_limit": 125,
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "looksrare_url": "https://looksrare.org/collections/0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "mapped_address": "0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "name": "Fidenza",
@@ -323,7 +323,7 @@
       "type": "range"
     },
     "debt_limit": 50,
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "looksrare_url": "https://looksrare.org/collections/0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "mapped_address": "0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "name": "Gazers",
@@ -634,7 +634,7 @@
       "type": "range"
     },
     "debt_limit": 50,
-    "floor_multiple_cap": 0.0,
+    "floor_multiple_cap": null,
     "looksrare_url": "https://looksrare.org/collections/0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "mapped_address": "0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270",
     "name": "Ringers",


### PR DESCRIPTION
## Purpose of this PR 🎯

<!-- Check at least one of the following options with an "x". -->
-   [x] Feature;
-   [ ] Bugfix;
-   [ ] Tests;
-   [ ] Refactoring;
-   [ ] Build or CI/CD; 
-   [ ] Documentation;
-   [ ] Code Styling;
-   [ ] Other. Please describe:

## Changes 📝
Use null values for `floor_multiple_cap` in Art Blocks collections. This value will be ignore while calculating the max value.
<!-- Describe the changes introduced by this PR. -->
<!-- If applicable add screenshots or videos that illustrate any new or updated UIs. -->

## Test Coverage 🧻

<!-- Add test coverage related to the introduced changes. -->

## Does this PR introduce a breaking change? ⚠️

-   [x] No
-   [ ] Yes

<!-- If yes, please describe the impact. -->

## Related issues 📎

<!-- If this PR refers to a JIRA ticket, uncomment and insert the issue number. -->
<!-- JIRA issue [POC-XXX](https://zharta.atlassian.net/browse/POC-XXX)-->

<!-- If this PR closes an issue, uncomment and insert the issue number. -->
<!-- Closes #ISSUE_NUMBER.-->

<!-- If not applicable, uncomment the line below. -->
<!-- _Not Applicable_ -->

<!-- If this PR depends on another PR, uncomment and add it below. -->
<!-- ### :warning: This PR depends on #XXX. -->
<!-- Give a quick overview of what is depending on. -->

## Reviewers 🦺

<!-- @DioPires -->

<!-- If applicable add other reviewers. -->
