### PR TITLE
separate otherdeedkodas from otherdeed

### DIFF
--- a/configs/dev/collections.json
+++ b/configs/dev/collections.json
@@ -665,7 +665,11 @@
   "otherdeed": {
     "appraisal_method": "otherdeeds",
     "contract_address": "0x70bC6D873D110Da59a9c49E7485a27B0F605E5db",
-    "debt_limit": 150,
+    "criteria": {
+      "set_name": "kodas",
+      "type": "token_not_in_set"
+    },
+    "debt_limit": 25,
     "floor_multiple_cap": 1.0,
     "image_url": "https://i.seadn.io/gae/yIm-M5-BpSDdTEIJRt5D6xphizhIdozXjqSITgK4phWq7MmAU3qE7Nw7POGCiPGyhtJ3ZFP8iJ29TFl-RLcGBWX5qI4-ZcnCPcsY4zI",
     "looksrare_url": "https://looksrare.org/collections/0x34d85c9CDeB23FA97cb08333b511ac86E1C4E258",
@@ -709,6 +713,46 @@
     "name": "[Internal] Otherdeed Expanded",
     "opensea_slug": "otherdeed-expanded",
     "opensea_url": "https://opensea.io/collection/otherdeed-expanded",
+    "pricing": {
+      "interest_rate": 0.01643,
+      "max_ltv": 0.55
+    },
+    "tier_pricing": {
+      "30d": {
+        "apr": 0.2,
+        "ltv": 0.6
+      },
+      "7d": {
+        "apr": 0.4,
+        "ltv": 0.675
+      },
+      "90d": {
+        "apr": 0.095,
+        "ltv": 0.4
+      }
+    },
+    "tiers": [
+      "7d",
+      "30d",
+      "90d"
+    ],
+    "whitelisted": true
+  },
+  "otherdeedkoda": {
+    "appraisal_method": "otherdeeds",
+    "contract_address": "0x70bC6D873D110Da59a9c49E7485a27B0F605E5db",
+    "criteria": {
+      "set_name": "kodas",
+      "type": "token_in_set"
+    },
+    "debt_limit": 50,
+    "floor_multiple_cap": 1.0,
+    "image_url": "https://i.seadn.io/gae/yIm-M5-BpSDdTEIJRt5D6xphizhIdozXjqSITgK4phWq7MmAU3qE7Nw7POGCiPGyhtJ3ZFP8iJ29TFl-RLcGBWX5qI4-ZcnCPcsY4zI",
+    "looksrare_url": "https://looksrare.org/collections/0x34d85c9CDeB23FA97cb08333b511ac86E1C4E258",
+    "mapped_address": "0x34d85c9CDeB23FA97cb08333b511ac86E1C4E258",
+    "name": "[Internal] Otherdeed for Otherside",
+    "opensea_slug": "otherdeed",
+    "opensea_url": "https://opensea.io/collection/otherdeed",
     "pricing": {
       "interest_rate": 0.01643,
       "max_ltv": 0.55

--- a/scripts/deployment.py
+++ b/scripts/deployment.py
@@ -132,7 +132,7 @@ def load_nft_contracts(env: Environment) -> list[NFT]:
         NFT("wgame", None),
         NFT("wgamefarmer", None),
         NFT("wgameland", None),
-        # NFT("otherdeedkoda", None),
+        NFT("otherdeedkoda", None),
         NFT("degods", None),
         NFT("othersidekoda", None),
         NFT("otherdeedexpanded", None),
@@ -289,7 +289,7 @@ def console():
     wgame = dm.context["wgame"].contract
     wgamefarmer = dm.context["wgamefarmer"].contract
     wgameland = dm.context["wgameland"].contract
-    # otherdeedkoda = dm.context["otherdeedkoda"].contract
+    otherdeedkoda = dm.context["otherdeedkoda"].contract
     degods = dm.context["degods"].contract
     othersidekoda = dm.context["othersidekoda"].contract
     otherdeedexpanded = dm.context["otherdeedexpanded"].contract


### PR DESCRIPTION
## Purpose of this PR 🎯

<!-- Check at least one of the following options with an "x". -->
-   [x] Feature;
-   [ ] Bugfix;
-   [ ] Tests;
-   [ ] Refactoring;
-   [ ] Build or CI/CD; 
-   [ ] Documentation;
-   [ ] Code Styling;
-   [ ] Other. Please describe:

## Changes 📝
This PR separates the `otherdeedkoda` collection from `otherdeed` based on a set criteria for the token ids that include the Koda trait and are not yet decoupled (5089 atm)



Currently only deployed in DEV for testing
<!-- Describe the changes introduced by this PR. -->
<!-- If applicable add screenshots or videos that illustrate any new or updated UIs. -->

## Test Coverage 🧻

<!-- Add test coverage related to the introduced changes. -->

## Does this PR introduce a breaking change? ⚠️

-   [ ] No
-   [ ] Yes

<!-- If yes, please describe the impact. -->

## Related issues 📎

<!-- If this PR refers to a JIRA ticket, uncomment and insert the issue number. -->
<!-- JIRA issue [POC-XXX](https://zharta.atlassian.net/browse/POC-XXX)-->

<!-- If this PR closes an issue, uncomment and insert the issue number. -->
<!-- Closes #ISSUE_NUMBER.-->

<!-- If not applicable, uncomment the line below. -->
<!-- _Not Applicable_ -->

<!-- If this PR depends on another PR, uncomment and add it below. -->
<!-- ### :warning: This PR depends on #XXX. -->
<!-- Give a quick overview of what is depending on. -->

## Reviewers 🦺

<!-- @DioPires -->

<!-- If applicable add other reviewers. -->
