### PR TITLE
fix: added support for adding a liquidation without NFTx token pair

### DIFF
--- a/contracts/LiquidationsPeripheral.vy
+++ b/contracts/LiquidationsPeripheral.vy
@@ -368,6 +368,10 @@ def _getAutoLiquidationPrice(_collateralAddress: address, _tokenId: uint256) -> 
     if not INFTXVault(vaultAddr).allValidNFTs([_tokenId]):
         return 0
 
+    # wrong setup of Sushi router
+    if ISushiRouter(self.sushiRouterAddress).factory() == empty(address):
+        return 0
+    
     # token pair does not exist
     if ISushiFactory(ISushiRouter(self.sushiRouterAddress).factory()).getPair(vaultAddr, wethAddress) == empty(address):
         return 0

--- a/contracts/LiquidationsPeripheral.vy
+++ b/contracts/LiquidationsPeripheral.vy
@@ -36,10 +36,8 @@ interface ILiquidationsCore:
     def addLoanToLiquidated(_borrower: address, _loansCoreContract: address, _loanId: uint256): nonpayable
     def removeLiquidation(_collateralAddress: address, _tokenId: uint256): nonpayable
 
-
 interface ILoansCore:
     def getLoan(_borrower: address, _loanId: uint256) -> Loan: view
-
 
 interface ILendingPoolPeripheral:
     def lenderFunds(_lender: address) -> InvestorFunds: view
@@ -62,15 +60,17 @@ interface ILendingPoolPeripheral:
     def lendingPoolCoreContract() -> address: view
     def protocolFeesShare() -> uint256: view
 
-
 interface ICollateralVaultPeripheral:
     def vaultAddress(_collateralAddress: address, _tokenId: uint256) -> address: view
     def isCollateralInVault(_collateralAddress: address, _tokenId: uint256) -> bool: view
     def transferCollateralFromLiquidation(_wallet: address, _collateralAddress: address, _tokenId: uint256): nonpayable
     def collateralVaultCoreDefaultAddress() -> address: view
 
+interface ISushiFactory:
+    def getPair(tokenA: address, tokenB: address) -> address: view
 
 interface ISushiRouter:
+    def factory() -> address: view
     def getAmountsOut(amountIn: uint256, path: DynArray[address, 2]) -> DynArray[uint256, 2]: view
     def swapExactTokensForTokens(
         amountIn: uint256,
@@ -99,6 +99,7 @@ interface CryptoPunksMarket:
 
 interface WrappedPunk:
     def burn(punkIndex: uint256): nonpayable
+
 
 # Structs
 
@@ -365,6 +366,10 @@ def _getAutoLiquidationPrice(_collateralAddress: address, _tokenId: uint256) -> 
         return 0
 
     if not INFTXVault(vaultAddr).allValidNFTs([_tokenId]):
+        return 0
+
+    # token pair does not exist
+    if ISushiFactory(ISushiRouter(self.sushiRouterAddress).factory()).getPair(vaultAddr, wethAddress) == empty(address):
         return 0
 
     mintFee: uint256 = self._getNFTXVaultMintFee(vaultAddr)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -243,6 +243,11 @@ def hashmasks_contract(contract_owner, erc721_contract_def):
 
 
 @pytest.fixture(scope="module")
+def otherdeed_for_otherside_contract(contract_owner, erc721_contract_def):
+    return erc721_contract_def.at("0x34d85c9CDeB23FA97cb08333b511ac86E1C4E258")
+
+
+@pytest.fixture(scope="module")
 def delegation_registry_contract(contract_owner, delegation_registry_contract_def):
     return delegation_registry_contract_def.at("0x00000000000076A84feF008CDAbe6409d2FE638B")
 


### PR DESCRIPTION
## Purpose of this PR 🎯

<!-- Check at least one of the following options with an "x". -->
-   [ ] Feature;
-   [x] Bugfix;
-   [ ] Tests;
-   [ ] Refactoring;
-   [ ] Build or CI/CD; 
-   [ ] Documentation;
-   [ ] Code Styling;
-   [ ] Other. Please describe:

## Changes 📝

<!-- Describe the changes introduced by this PR. -->
<!-- If applicable add screenshots or videos that illustrate any new or updated UIs. -->
This PR adds support for adding liquidations when an NFT has an NFTx vault without the corresponding liquidity pool available on Sushi.